### PR TITLE
Remove duplicate titles.

### DIFF
--- a/data/orgchart.json
+++ b/data/orgchart.json
@@ -26,7 +26,6 @@
 		"titles": [
 			"Chief Community Manager",
 			"Community Manager",
-			"Events Manager",
 			"Onboarding Officer",
 			"Internal Communication Officer",
 			"Regional Manager – Bucharest",
@@ -56,7 +55,6 @@
 		"titles": [
 			"Chief Fundraising Officer",
 			"Fundraising Officer",
-			"Grants Officer",
 			"Accountant"
 		]
 	},


### PR DESCRIPTION
Remove "Grants Office" from "Funding".
Remove "Events Manager" from "Community Management".